### PR TITLE
Implement Bun disk space agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,20 @@
 # mcp-space-browser
 
-Design documentation for MCP agents that analyze disk usage can be found in [docs/disk_agent_design.md](docs/disk_agent_design.md).
+This project implements a disk space indexing agent using the Bun runtime.
+See [docs/disk_agent_design.md](docs/disk_agent_design.md) for the design.
 
+## Usage
+
+Install [Bun](https://bun.sh/) and run one of the CLI commands:
+
+```bash
+bun src/cli.ts disk-index /path/to/scan
+bun src/cli.ts disk-du /path
+bun src/cli.ts disk-tree /path
+```
+
+A simple HTTP server is available via:
+
+```bash
+bun src/server.ts
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,75 @@
+{
+  "name": "mcp-space-browser",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "mcp-space-browser",
+      "version": "0.1.0",
+      "devDependencies": {
+        "@types/bun": "^1.2.18",
+        "@types/node": "^24.0.14"
+      }
+    },
+    "node_modules/@types/bun": {
+      "version": "1.2.18",
+      "resolved": "https://registry.npmjs.org/@types/bun/-/bun-1.2.18.tgz",
+      "integrity": "sha512-Xf6RaWVheyemaThV0kUfaAUvCNokFr+bH8Jxp+tTZfx7dAPA8z9ePnP9S9+Vspzuxxx9JRAXhnyccRj3GyCMdQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bun-types": "1.2.18"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "24.0.14",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.0.14.tgz",
+      "integrity": "sha512-4zXMWD91vBLGRtHK3YbIoFMia+1nqEz72coM42C5ETjnNCa/heoj7NT1G67iAfOqMmcfhuCZ4uNpyz8EjlAejw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.8.0"
+      }
+    },
+    "node_modules/@types/react": {
+      "version": "19.1.8",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.8.tgz",
+      "integrity": "sha512-AwAfQ2Wa5bCx9WP8nZL2uMZWod7J7/JSplxbTmBQ5ms6QpqNYm672H0Vu9ZVKVngQ+ii4R/byguVEUZQyeg44g==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/bun-types": {
+      "version": "1.2.18",
+      "resolved": "https://registry.npmjs.org/bun-types/-/bun-types-1.2.18.tgz",
+      "integrity": "sha512-04+Eha5NP7Z0A9YgDAzMk5PHR16ZuLVa83b26kH5+cp1qZW4F6FmAURngE7INf4tKOvCE69vYvDEwoNl1tGiWw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      },
+      "peerDependencies": {
+        "@types/react": "^19"
+      }
+    },
+    "node_modules/csstype": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
+      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/undici-types": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.8.0.tgz",
+      "integrity": "sha512-9UJ2xGDvQ43tYyVMpuHlsgApydB8ZKfVYTsLDhXkFL/6gfkp+U8xTGdh8pMJv1SpZna0zxG1DwsKZsreLbXBxw==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "mcp-space-browser",
+  "version": "0.1.0",
+  "type": "module",
+  "scripts": {
+    "start": "bun src/cli.ts",
+    "test": "bun test"
+  },
+  "devDependencies": {
+    "@types/bun": "^1.2.18",
+    "@types/node": "^24.0.14"
+  }
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,0 +1,49 @@
+import { DiskDB } from './db';
+import { index as indexFs } from './crawler';
+import * as path from 'path';
+
+async function diskIndex(target: string) {
+  const db = new DiskDB();
+  await indexFs(target, db);
+}
+
+function diskDu(target: string) {
+  const db = new DiskDB();
+  const abs = path.resolve(target);
+  const row = db.db
+    .query('SELECT size FROM entries WHERE path = ?')
+    .get(abs) as { size: number } | undefined;
+  console.log(row?.size ?? 0);
+}
+
+function diskTree(target: string, indent = '') {
+  const db = new DiskDB();
+  const abs = path.resolve(target);
+  const entry = db.get(abs);
+  if (!entry) return;
+  console.log(`${indent}${path.basename(abs)} (${entry.size})`);
+  const children = db.children(abs);
+  for (const child of children) {
+    diskTree(child.path, indent + '  ');
+  }
+}
+
+async function main() {
+  const [cmd, arg] = process.argv.slice(2);
+  if (!cmd || !arg) {
+    console.log('Usage: disk-index|disk-du|disk-tree <path>');
+    process.exit(1);
+  }
+  if (cmd === 'disk-index') {
+    await diskIndex(arg);
+  } else if (cmd === 'disk-du') {
+    diskDu(arg);
+  } else if (cmd === 'disk-tree') {
+    diskTree(arg);
+  } else {
+    console.log('Unknown command');
+    process.exit(1);
+  }
+}
+
+main();

--- a/src/crawler.ts
+++ b/src/crawler.ts
@@ -1,0 +1,31 @@
+import { promises as fs } from 'fs';
+import * as path from 'path';
+import { DiskDB } from './db';
+
+export async function index(root: string, db: DiskDB) {
+  const abs = path.resolve(root);
+  const runId = Date.now();
+  const stack: string[] = [abs];
+  while (stack.length) {
+    const current = stack.pop()!;
+    const info = await fs.stat(current);
+    const isDir = info.isDirectory();
+    db.insertOrUpdate({
+      path: current,
+      parent: path.dirname(current) === current ? null : path.dirname(current),
+      size: info.size,
+      kind: isDir ? 'directory' : 'file',
+      ctime: info.ctimeMs,
+      mtime: info.mtimeMs,
+      last_scanned: runId
+    });
+    if (isDir) {
+      const children = await fs.readdir(current);
+      for (const c of children) {
+        stack.push(path.join(current, c));
+      }
+    }
+  }
+  db.deleteStale(abs, runId);
+  db.computeAggregates(abs);
+}

--- a/src/db.ts
+++ b/src/db.ts
@@ -1,0 +1,96 @@
+import { Database } from 'bun:sqlite';
+
+export interface Entry {
+  id?: number;
+  path: string;
+  parent: string | null;
+  size: number;
+  kind: 'file' | 'directory';
+  ctime: number;
+  mtime: number;
+  last_scanned: number;
+}
+
+export class DiskDB {
+  db: Database;
+
+  constructor(path: string = 'disk.db') {
+    this.db = new Database(path);
+    this.init();
+  }
+
+  private init() {
+    this.db.run(`CREATE TABLE IF NOT EXISTS entries (
+      id INTEGER PRIMARY KEY,
+      path TEXT UNIQUE NOT NULL,
+      parent TEXT,
+      size INTEGER,
+      kind TEXT CHECK(kind IN ('file', 'directory')),
+      ctime INTEGER,
+      mtime INTEGER,
+      last_scanned INTEGER,
+      dirty INTEGER DEFAULT 0
+    )`);
+    this.db.run('CREATE INDEX IF NOT EXISTS idx_parent ON entries(parent)');
+  }
+
+  insertOrUpdate(entry: Entry): void {
+    const stmt = this.db.prepare(`
+      INSERT INTO entries
+        (path, parent, size, kind, ctime, mtime, last_scanned, dirty)
+      VALUES (?, ?, ?, ?, ?, ?, ?, 0)
+      ON CONFLICT(path) DO UPDATE SET
+        parent=excluded.parent,
+        size=excluded.size,
+        kind=excluded.kind,
+        ctime=excluded.ctime,
+        mtime=excluded.mtime,
+        last_scanned=excluded.last_scanned,
+        dirty=0
+    `);
+    stmt.run(
+      entry.path,
+      entry.parent,
+      entry.size,
+      entry.kind,
+      entry.ctime,
+      entry.mtime,
+      entry.last_scanned
+    );
+  }
+
+  deleteStale(root: string, runId: number) {
+    this.db
+      .query(
+        `DELETE FROM entries WHERE (path = ? OR path LIKE ?) AND last_scanned < ?`
+      )
+      .run(root, `${root}/%`, runId);
+  }
+
+  computeAggregates(root: string) {
+    const dirs = this.db
+      .query(
+        `SELECT path FROM entries WHERE kind = 'directory' AND (path = ? OR path LIKE ?) ORDER BY length(path) DESC`
+      )
+      .all(root, `${root}/%`) as { path: string }[];
+    for (const d of dirs) {
+      const row = this.db
+        .query(`SELECT SUM(size) as total FROM entries WHERE parent = ?`)
+        .get(d.path) as { total: number } | undefined;
+      const total = row?.total ?? 0;
+      this.db.query(`UPDATE entries SET size = ? WHERE path = ?`).run(total, d.path);
+    }
+  }
+
+  children(parent: string): Entry[] {
+    return this.db
+      .query(`SELECT * FROM entries WHERE parent = ?`)
+      .all(parent) as Entry[];
+  }
+
+  get(path: string): Entry | undefined {
+    return this.db
+      .query(`SELECT * FROM entries WHERE path = ?`)
+      .get(path) as Entry | undefined;
+  }
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,0 +1,31 @@
+import { DiskDB } from './db';
+import { index as indexFs } from './crawler';
+import * as path from 'path';
+
+const db = new DiskDB();
+
+const server = Bun.serve({
+  port: 3000,
+  fetch(req, server) {
+    const url = new URL(req.url);
+    if (url.pathname === '/api/index') {
+      const p = url.searchParams.get('path');
+      if (!p) return new Response('path required', { status: 400 });
+      indexFs(p, db).then(() => console.log('indexed', p));
+      return new Response('OK');
+    } else if (url.pathname === '/api/tree') {
+      const p = url.searchParams.get('path') || '.';
+      const abs = path.resolve(p);
+      function buildTree(root: string): any {
+        const entry = db.get(root);
+        if (!entry) return null;
+        const children = db.children(root).map((c) => buildTree(c.path));
+        return { path: root, size: entry.size, children: children.filter(Boolean) };
+      }
+      return Response.json(buildTree(abs));
+    }
+    return new Response('Not found', { status: 404 });
+  },
+});
+
+console.log('server running on', server.port);

--- a/test/agent.test.ts
+++ b/test/agent.test.ts
@@ -1,0 +1,52 @@
+import { test, expect } from 'bun:test';
+import { DiskDB } from '../src/db';
+import { index } from '../src/crawler';
+import { promises as fs } from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+
+async function withTempDir(fn: (dir: string) => Promise<void>) {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'disk-test-'));
+  try {
+    await fn(dir);
+  } finally {
+    await fs.rm(dir, { recursive: true, force: true });
+  }
+}
+
+test('index recurses and records entries', async () => {
+  await withTempDir(async (dir) => {
+    await fs.writeFile(path.join(dir, 'file1'), 'hello');
+    await fs.mkdir(path.join(dir, 'sub'));
+    await fs.writeFile(path.join(dir, 'sub', 'file2'), 'hi');
+
+    const db = new DiskDB(':memory:');
+    await index(dir, db);
+
+    expect(db.get(path.join(dir, 'file1'))).toBeTruthy();
+    expect(db.get(path.join(dir, 'sub', 'file2'))).toBeTruthy();
+
+    const rootEntry = db.get(dir)!;
+    expect(rootEntry.size).toBe(7);
+  });
+});
+
+test('aggregated size updates when file deleted', async () => {
+  await withTempDir(async (dir) => {
+    const f1 = path.join(dir, 'a');
+    const sub = path.join(dir, 'sub');
+    const f2 = path.join(sub, 'b');
+
+    await fs.writeFile(f1, 'aa');
+    await fs.mkdir(sub);
+    await fs.writeFile(f2, 'bbb');
+
+    const db = new DiskDB(':memory:');
+    await index(dir, db);
+    expect(db.get(dir)!.size).toBe(5);
+
+    await fs.rm(f2);
+    await index(dir, db);
+    expect(db.get(dir)!.size).toBe(2);
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "node",
+    "strict": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
+    "types": ["node", "bun-types"]
+  }
+}


### PR DESCRIPTION
## Summary
- implement SQLite database layer
- create filesystem crawler
- add CLI for `disk-index`, `disk-du`, and `disk-tree`
- provide a simple HTTP server for browsing disk usage
- document usage in README
- compute aggregate directory sizes and remove stale entries
- add unit tests for crawler and DB

## Testing
- `npm test --silent`
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_687665b1f9ac8328b6d95ff8ceecfa80